### PR TITLE
Fix Slack notification webhook

### DIFF
--- a/sama/Services/SlackNotificationService.cs
+++ b/sama/Services/SlackNotificationService.cs
@@ -104,7 +104,13 @@ namespace sama.Services
                 using var httpHandler = _serviceProvider.GetRequiredService<HttpClientHandler>();
                 using var client = new HttpClient(httpHandler, false);
                 var data = JsonConvert.SerializeObject(new { text = message });
-                client.PostAsync(url, new StringContent(data)).Wait();
+                var content = new StringContent(data);
+                content.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json");
+                using var response = client.PostAsync(url, content).Result;
+                if (!response.IsSuccessStatusCode)
+                {
+                    _logger.LogError(0, $"Unable to send Slack notification: HTTP {(int)response.StatusCode}", new Exception(response.Content.ReadAsStringAsync().Result));
+                }
             }
             catch (Exception ex)
             {

--- a/sama/sama.csproj
+++ b/sama/sama.csproj
@@ -8,8 +8,8 @@
     <MvcRazorCompileOnPublish>true</MvcRazorCompileOnPublish>
     <AssetTargetFallback>$(AssetTargetFallback);portable-net45+win8+wp8+wpa81;</AssetTargetFallback>
     <UserSecretsId>aspnet-WebApplication1-1C1369D5-B3C7-4414-ADD2-629BA88766C5</UserSecretsId>
-    <AssemblyVersion>1.2.2</AssemblyVersion>
-    <VersionPrefix>1.2.2</VersionPrefix>
+    <AssemblyVersion>1.2.3</AssemblyVersion>
+    <VersionPrefix>1.2.3</VersionPrefix>
     <VersionSuffix>$([System.DateTime]::UtcNow.ToString(`yyyyMMdd-HHmm`))</VersionSuffix>
   </PropertyGroup>
 


### PR DESCRIPTION
- Use correct Content-Type header (fixes Discord Slack-compatible webhooks)
- Dispose of response object correctly