### PR TITLE
Read stdout/stderr from scripts early

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN dotnet publish -c release -o /app --no-restore /p:MinVerSkip=true /p:Version
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get install -y iputils-ping tini curl python3-venv python3-pip \
  && apt-get clean

--- a/Dockerfile-buildx-amd64
+++ b/Dockerfile-buildx-amd64
@@ -21,7 +21,6 @@ RUN dotnet publish -c release -o /app --no-restore /p:MinVerSkip=true /p:Version
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get install -y iputils-ping tini curl python3-venv python3-pip \
  && apt-get clean

--- a/Dockerfile-buildx-amd64.sudo
+++ b/Dockerfile-buildx-amd64.sudo
@@ -22,7 +22,6 @@ RUN dotnet publish -c release -o /app --no-restore /p:MinVerSkip=true /p:Version
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get install -y iputils-ping tini curl python3-venv python3-pip sudo \
  && apt-get clean

--- a/Dockerfile.sudo
+++ b/Dockerfile.sudo
@@ -22,7 +22,6 @@ RUN dotnet publish -c release -o /app --no-restore /p:MinVerSkip=true /p:Version
 
 # final stage/image
 FROM mcr.microsoft.com/dotnet/aspnet:10.0
-ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
  && apt-get install -y iputils-ping tini curl python3-venv python3-pip sudo \
  && apt-get clean

--- a/SAMA.Shared/Checks/ScriptCheckExecutor.cs
+++ b/SAMA.Shared/Checks/ScriptCheckExecutor.cs
@@ -82,6 +82,10 @@ public class ScriptCheckExecutor(ProcessFactory _processFactory) : ICheckExecuto
             timestamp = Stopwatch.GetTimestamp();
             process.Start(startInfo);
 
+            // Start reading stdout/stderr immediately to prevent buffer deadlock.
+            var stdoutTask = process.ReadStandardOutputAsync(CancellationToken.None);
+            var stderrTask = process.ReadStandardErrorAsync(CancellationToken.None);
+
             var timedOut = false;
             try
             {
@@ -104,9 +108,9 @@ public class ScriptCheckExecutor(ProcessFactory _processFactory) : ICheckExecuto
             var executionTime = Stopwatch.GetElapsedTime(timestamp.Value);
             var executionTimeMs = (int)executionTime.TotalMilliseconds;
 
-            // Always capture stdout/stderr for script checks (even on timeout)
-            var stdout = await process.ReadStandardOutputAsync(CancellationToken.None);
-            var stderr = await process.ReadStandardErrorAsync(CancellationToken.None);
+            // Await the output tasks - they complete when streams close (process exits or is killed)
+            var stdout = await stdoutTask;
+            var stderr = await stderrTask;
 
             if (timedOut)
             {

--- a/SAMA.Web/Services/NotificationChannels/ScriptChannelHandler.cs
+++ b/SAMA.Web/Services/NotificationChannels/ScriptChannelHandler.cs
@@ -213,6 +213,10 @@ public class ScriptChannelHandler(
             timestamp = Stopwatch.GetTimestamp();
             process.Start(startInfo);
 
+            // Start reading stdout/stderr immediately to prevent buffer deadlock.
+            var stdoutTask = process.ReadStandardOutputAsync(CancellationToken.None);
+            var stderrTask = process.ReadStandardErrorAsync(CancellationToken.None);
+
             var timedOut = false;
             try
             {
@@ -234,6 +238,11 @@ public class ScriptChannelHandler(
 
             var executionTime = Stopwatch.GetElapsedTime(timestamp.Value);
             var executionTimeMs = (int)executionTime.TotalMilliseconds;
+
+            // Await the output tasks - they complete when streams close (process exits or is killed)
+            // We discard stdout but must drain it to prevent buffer deadlock
+            _ = await stdoutTask;
+            var stderr = await stderrTask;
 
             if (timedOut)
             {
@@ -268,8 +277,6 @@ public class ScriptChannelHandler(
                     SentAt = sentAt
                 };
             }
-
-            var stderr = await process.ReadStandardErrorAsync(CancellationToken.None);
             var errorMessage = string.IsNullOrWhiteSpace(stderr)
                 ? $"Script exited with code {exitCode}"
                 : $"Script exited with code {exitCode}: {TruncateErrorMessage(stderr.Trim())}";


### PR DESCRIPTION
This fixes issues where the buffer can fill up and freeze the script