### PR TITLE
Hide script contents on display pages

### DIFF
--- a/SAMA.Web/Pages/Checks/_ScriptCheckConfigDisplay.cshtml
+++ b/SAMA.Web/Pages/Checks/_ScriptCheckConfigDisplay.cshtml
@@ -28,7 +28,7 @@
         {
             <dt class="col-sm-4">Inline Script</dt>
             <dd class="col-sm-8 mb-0">
-                <pre class="p-2 rounded small mb-0" style="max-height: 200px; overflow-y: auto;"><code>@scriptContent</code></pre>
+                <span class="text-muted">••••••••</span>
             </dd>
         }
     </dl>

--- a/SAMA.Web/Pages/NotificationChannels/_ScriptConfigDisplay.cshtml
+++ b/SAMA.Web/Pages/NotificationChannels/_ScriptConfigDisplay.cshtml
@@ -32,7 +32,7 @@
         {
             <dt class="col-sm-4">Inline Script</dt>
             <dd class="col-sm-8 mb-0">
-                <pre class="bg-light p-2 rounded small mb-0" style="max-height: 200px; overflow-y: auto;"><code>@scriptContent</code></pre>
+                <span class="text-muted">••••••••</span>
             </dd>
         }
     </dl>


### PR DESCRIPTION
Scripts may have sensitive information, which should not be shown to those potentially without edit privileges.